### PR TITLE
feat: drag and drop to reorder time zones

### DIFF
--- a/src/components/ZoneList.tsx
+++ b/src/components/ZoneList.tsx
@@ -47,6 +47,8 @@ export function ZoneList({ zones, zoneInfos, onRemove, onReorder, onTimeTyped }:
         const info = zoneInfos.get(zone.id);
         if (!info) return null;
 
+        const isOver = overIndex === index && dragIndex !== null && dragIndex !== index;
+
         return (
           <div
             key={zone.id}
@@ -54,6 +56,7 @@ export function ZoneList({ zones, zoneInfos, onRemove, onReorder, onTimeTyped }:
             onDragStart={(e) => handleDragStart(e, index)}
             onDragEnd={handleDragEnd}
             onDragOver={(e) => handleDragOver(e, index)}
+            style={{ cursor: "grab", borderTop: isOver ? "1px solid rgba(74,222,128,0.4)" : "1px solid transparent" }}
           >
             <ZoneRow
               zoneId={zone.id}


### PR DESCRIPTION
<!-- rpb-last-action: implement:23781433454 -->

## Summary

Fixes #1

Drag-and-drop reordering of time zones was already structurally implemented (drag handlers in `ZoneList.tsx`, `reorderZones` in `usePreferences.ts`, wired up in `App.tsx`), but was missing the visual polish that makes it discoverable and usable:

- **No drop-target indicator**: `overIndex` state was tracked but never applied visually, so users had no feedback about where the dragged item would land.
- **No drag affordance**: Rows gave no visual cue that they were draggable.

## Changes

- `src/components/ZoneList.tsx`: Show a green (`rgba(74,222,128,0.4)`) top border on the row being dragged over, matching the app's existing green accent color. Apply `cursor: grab` to all draggable rows to signal interactivity.

## Trade-offs

Kept the implementation minimal — the existing HTML5 drag-and-drop API is sufficient and requires no new dependencies (no drag library), keeping the app well under its 5 MB size budget.