### PR TITLE
feat: add Windows tray support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npm install
 npm run tauri dev
 ```
 
-Requires [Rust](https://rustup.rs/) and [Node.js 22+](https://nodejs.org/).
+Requires [Rust](https://rustup.rs/) and [Node.js 22+](https://nodejs.org/). 
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 **Stop doing timezone math in your head.**
 
-A Mac menu bar app that shows the time everywhere you care about.
+A macOS and Windows tray app that shows the time everywhere you care about.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![macOS](https://img.shields.io/badge/macOS-14%2B-000?logo=apple&logoColor=white)](https://github.com/yazinsai/zonebar/releases/latest)
+[![Windows](https://img.shields.io/badge/Windows-10%2B-0078D4?logo=windows&logoColor=white)](https://github.com/yazinsai/zonebar/releases/latest)
 [![GitHub release](https://img.shields.io/github/v/release/yazinsai/zonebar?color=%234ade80)](https://github.com/yazinsai/zonebar/releases/latest)
 [![GitHub downloads](https://img.shields.io/github/downloads/yazinsai/zonebar/total?color=%234ade80)](https://github.com/yazinsai/zonebar/releases/latest)
 
@@ -15,6 +16,10 @@ A Mac menu bar app that shows the time everywhere you care about.
 
 <a href="https://github.com/yazinsai/zonebar/releases/latest">
   <img src="https://img.shields.io/badge/Download_for_Mac-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for Mac" height="40" />
+</a>
+&nbsp;
+<a href="https://github.com/yazinsai/zonebar/releases/latest">
+  <img src="https://img.shields.io/badge/Download_for_Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" height="40" />
 </a>
 
 <br /><br />
@@ -31,9 +36,15 @@ Click the clock in your menu bar. See the time in every zone you've added — wi
 
 ## Install
 
+**macOS**
 1. [Download the DMG](https://github.com/yazinsai/zonebar/releases/latest)
 2. Drag ZoneBar to Applications
 3. Launch — look for the clock in your menu bar
+
+**Windows**
+1. [Download the MSI installer](https://github.com/yazinsai/zonebar/releases/latest)
+2. Run the installer
+3. Launch ZoneBar — look for the clock icon in the system tray (bottom-right)
 
 ## Features
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
+  "windows": ["main", "bar"],
   "permissions": [
     "core:default",
     "opener:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,39 +21,52 @@ fn read_preferences(app: tauri::AppHandle) -> Result<String, String> {
 
 #[tauri::command]
 fn toggle_popup(app: tauri::AppHandle) -> Result<(), String> {
-    if let Some(main) = app.get_webview_window("main") {
-        if main.is_visible().unwrap_or(false) {
-            let _ = main.hide();
-        } else {
-            if let Some(bar) = app.get_webview_window("bar") {
-                if let (Ok(bar_pos), Ok(bar_size), Ok(main_size)) = (
-                    bar.outer_position(),
-                    bar.outer_size(),
-                    main.outer_size(),
-                ) {
-                    let x = bar_pos.x + bar_size.width as i32 - main_size.width as i32;
-                    let y = bar_pos.y - main_size.height as i32 - 4;
-                    let _ = main.set_position(tauri::Position::Physical(
-                        tauri::PhysicalPosition { x: x.max(0), y: y.max(0) },
-                    ));
-                }
-            }
-            let _ = main.show();
-            let _ = main.set_focus();
-            let _ = main.emit("popover-opened", ()).ok();
+    let Some(main) = app.get_webview_window("main") else { return Ok(()); };
+
+    if main.is_visible().unwrap_or(false) {
+        let _ = main.hide();
+        return Ok(());
+    }
+
+    // Position popup above the taskbar on the same monitor as the bar widget
+    if let Some(bar) = app.get_webview_window("bar") {
+        if let (Ok(bar_pos), Ok(bar_size), Ok(main_size)) = (bar.outer_position(), bar.outer_size(), main.outer_size()) {
+            let (x, y): (i32, i32) = if let Ok(Some(monitor)) = bar.current_monitor() {
+                let scale = monitor.scale_factor();
+                let mon_pos = monitor.position();
+                let mon_size = monitor.size();
+                let taskbar_physical = (48.0 * scale) as i32;
+                let popup_w = (280.0 * scale) as i32;
+                (
+                    mon_pos.x + mon_size.width as i32 - popup_w,
+                    mon_pos.y + mon_size.height as i32 - taskbar_physical - main_size.height as i32 - 4,
+                )
+            } else {
+                (
+                    bar_pos.x + bar_size.width as i32 - 280,
+                    bar_pos.y - main_size.height as i32 - 4,
+                )
+            };
+            let _ = main.set_position(tauri::Position::Physical(
+                tauri::PhysicalPosition { x: x.max(0), y: y.max(0) },
+            ));
         }
     }
+
+    let _ = main.show();
+    let _ = main.set_focus();
+    let _ = main.emit("popover-opened", ()).ok();
     Ok(())
 }
 
 #[tauri::command]
 fn resize_window(app: tauri::AppHandle, height: f64) -> Result<(), String> {
     if let Some(window) = app.get_webview_window("main") {
-        let current_size = window.outer_size().map_err(|e| e.to_string())?;
         let scale = window.scale_factor().unwrap_or(1.0);
+        let physical_width = (280.0 * scale) as u32;
         let physical_height = (height * scale) as u32;
         let _ = window.set_size(tauri::Size::Physical(tauri::PhysicalSize {
-            width: current_size.width,
+            width: physical_width,
             height: physical_height,
         }));
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,33 @@ fn read_preferences(app: tauri::AppHandle) -> Result<String, String> {
 }
 
 #[tauri::command]
+fn toggle_popup(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(main) = app.get_webview_window("main") {
+        if main.is_visible().unwrap_or(false) {
+            let _ = main.hide();
+        } else {
+            if let Some(bar) = app.get_webview_window("bar") {
+                if let (Ok(bar_pos), Ok(bar_size), Ok(main_size)) = (
+                    bar.outer_position(),
+                    bar.outer_size(),
+                    main.outer_size(),
+                ) {
+                    let x = bar_pos.x + bar_size.width as i32 - main_size.width as i32;
+                    let y = bar_pos.y - main_size.height as i32 - 4;
+                    let _ = main.set_position(tauri::Position::Physical(
+                        tauri::PhysicalPosition { x: x.max(0), y: y.max(0) },
+                    ));
+                }
+            }
+            let _ = main.show();
+            let _ = main.set_focus();
+            let _ = main.emit("popover-opened", ()).ok();
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
 fn resize_window(app: tauri::AppHandle, height: f64) -> Result<(), String> {
     if let Some(window) = app.get_webview_window("main") {
         let current_size = window.outer_size().map_err(|e| e.to_string())?;
@@ -49,10 +76,12 @@ fn toggle_popover(window: &WebviewWindow, tray_bounds: Option<(f64, f64, f64, f6
         #[cfg(target_os = "windows")]
         {
             // On Windows the taskbar is at the bottom, so TrayBottomCenter would place
-            // the window below the screen. Instead, position it above the tray icon.
+            // the window below the screen. Instead, right-align to the tray icon and
+            // appear above it — matching Windows convention (Action Center, calendar, etc.).
             if let Some((tray_x, tray_y, tray_w, _)) = tray_bounds {
                 if let Ok(win_size) = window.outer_size() {
-                    let x = (tray_x + tray_w / 2.0) as i32 - (win_size.width / 2) as i32;
+                    // Right edge of window aligns with right edge of tray icon
+                    let x = (tray_x + tray_w) as i32 - win_size.width as i32;
                     let y = tray_y as i32 - win_size.height as i32;
                     let _ = window.set_position(tauri::Position::Physical(
                         tauri::PhysicalPosition { x: x.max(0), y: y.max(0) },
@@ -77,7 +106,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_positioner::init())
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![read_preferences, write_preferences, resize_window])
+        .invoke_handler(tauri::generate_handler![read_preferences, write_preferences, resize_window, toggle_popup])
         .setup(|app| {
             // Hide from Dock on macOS
             #[cfg(target_os = "macos")]
@@ -124,7 +153,7 @@ pub fn run() {
                 })
                 .build(app)?;
 
-            // Hide popover on focus loss
+            // Hide popover on focus loss (main popup only, not the bar)
             if let Some(window) = app.get_webview_window("main") {
                 let w = window.clone();
                 window.on_window_event(move |event| {
@@ -132,6 +161,31 @@ pub fn run() {
                         let _ = w.hide();
                     }
                 });
+            }
+
+            // On Windows: position and show the always-visible taskbar bar
+            #[cfg(target_os = "windows")]
+            {
+                if let Some(bar) = app.get_webview_window("bar") {
+                    if let Ok(Some(monitor)) = bar.primary_monitor() {
+                        let scale = bar.scale_factor().unwrap_or(1.0);
+                        let phys = monitor.size();
+                        // Convert screen size to logical pixels for positioning
+                        let screen_w = phys.width as f64 / scale;
+                        let screen_h = phys.height as f64 / scale;
+                        // Windows taskbar is ~40px (Win10) or ~48px (Win11), clock ~130px wide
+                        let taskbar_h = 48.0f64;
+                        let clock_w  = 130.0f64;
+                        let bar_w    = 300.0f64;
+                        let bar_h    = 40.0f64;
+                        let x = screen_w - bar_w - clock_w;
+                        let y = screen_h - taskbar_h + (taskbar_h - bar_h) / 2.0;
+                        let _ = bar.set_position(tauri::Position::Logical(
+                            tauri::LogicalPosition { x, y },
+                        ));
+                        let _ = bar.show();
+                    }
+                }
             }
 
             Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,11 +42,30 @@ fn write_preferences(app: tauri::AppHandle, data: String) -> Result<(), String> 
     fs::write(&path, data).map_err(|e| e.to_string())
 }
 
-fn toggle_popover(window: &WebviewWindow) {
+fn toggle_popover(window: &WebviewWindow, tray_bounds: Option<(f64, f64, f64, f64)>) {
     if window.is_visible().unwrap_or(false) {
         let _ = window.hide();
     } else {
-        let _ = window.move_window(Position::TrayBottomCenter);
+        #[cfg(target_os = "windows")]
+        {
+            // On Windows the taskbar is at the bottom, so TrayBottomCenter would place
+            // the window below the screen. Instead, position it above the tray icon.
+            if let Some((tray_x, tray_y, tray_w, _)) = tray_bounds {
+                if let Ok(win_size) = window.outer_size() {
+                    let x = (tray_x + tray_w / 2.0) as i32 - (win_size.width / 2) as i32;
+                    let y = tray_y as i32 - win_size.height as i32;
+                    let _ = window.set_position(tauri::Position::Physical(
+                        tauri::PhysicalPosition { x: x.max(0), y: y.max(0) },
+                    ));
+                }
+            } else {
+                let _ = window.move_window(Position::TrayCenter);
+            }
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            let _ = window.move_window(Position::TrayBottomCenter);
+        }
         let _ = window.show();
         let _ = window.set_focus();
         let _ = window.emit("popover-opened", ());
@@ -79,7 +98,7 @@ pub fn run() {
                 .icon_as_template(true)
                 .tooltip("ZoneBar")
                 .menu(&menu)
-                .menu_on_left_click(false)
+                .show_menu_on_left_click(false)
                 .on_menu_event(|app, event| {
                     if event.id.as_ref() == "quit" {
                         app.exit(0);
@@ -87,10 +106,18 @@ pub fn run() {
                 })
                 .on_tray_icon_event(move |tray_handle, event| {
                     tauri_plugin_positioner::on_tray_event(tray_handle.app_handle(), &event);
-                    if let TrayIconEvent::Click { button_state, .. } = &event {
+                    if let TrayIconEvent::Click { button_state, rect, .. } = &event {
                         if matches!(button_state, MouseButtonState::Up) {
                             if let Some(window) = tray_handle.app_handle().get_webview_window("main") {
-                                toggle_popover(&window);
+                                let (tray_x, tray_y) = match &rect.position {
+                                    tauri::Position::Physical(p) => (p.x as f64, p.y as f64),
+                                    tauri::Position::Logical(l) => (l.x, l.y),
+                                };
+                                let (tray_w, tray_h) = match &rect.size {
+                                    tauri::Size::Physical(s) => (s.width as f64, s.height as f64),
+                                    tauri::Size::Logical(s) => (s.width, s.height),
+                                };
+                                toggle_popover(&window, Some((tray_x, tray_y, tray_w, tray_h)));
                             }
                         }
                     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
       {
         "label": "main",
         "title": "ZoneBar",
-        "width": 320,
+        "width": 280,
         "height": 280,
         "visible": false,
         "decorations": false,
@@ -24,6 +24,19 @@
         "alwaysOnTop": true,
         "resizable": false,
         "focus": true
+      },
+      {
+        "label": "bar",
+        "title": "ZoneBar",
+        "width": 300,
+        "height": 40,
+        "visible": false,
+        "decorations": false,
+        "transparent": true,
+        "skipTaskbar": true,
+        "alwaysOnTop": true,
+        "resizable": false,
+        "focus": false
       }
     ],
     "security": {

--- a/src/App.css
+++ b/src/App.css
@@ -61,3 +61,23 @@ input[type="range"]::-webkit-slider-thumb {
   cursor: pointer;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
+
+/* Bar window — floats in taskbar, no panel chrome */
+body.bar-window #root {
+  background: transparent;
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
+  height: 100vh;
+}
+
+body.bar-window .bar-root {
+  /* rgba > 0 so Windows captures click events on transparent windows */
+  background: rgba(0, 0, 0, 0.01);
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+body.bar-window .bar-root:hover {
+  background: rgba(255, 255, 255, 0.08);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,6 @@ function App() {
 
   // Auto-resize window to fit content
   useEffect(() => {
-    if (!loaded) return;
     const el = rootRef.current;
     if (!el) return;
     const resizeObserver = new ResizeObserver(() => {
@@ -35,7 +34,7 @@ function App() {
     });
     resizeObserver.observe(el);
     return () => resizeObserver.disconnect();
-  }, [loaded]);
+  }, []);
 
   // Global Esc handler
   useEffect(() => {
@@ -49,8 +48,6 @@ function App() {
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, []);
-
-  if (!loaded) return null;
 
   return (
     <div ref={rootRef} className="flex flex-col">

--- a/src/BarApp.tsx
+++ b/src/BarApp.tsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { usePreferences } from "./hooks/usePreferences";
+
+function formatTime(date: Date, zoneId: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: zoneId,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}
+
+export function BarApp() {
+  const { zones } = usePreferences();
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const handleClick = () => {
+    invoke("toggle_popup").catch(console.error);
+  };
+
+  // Show the first zone as the always-visible indicator
+  const primary = zones[0];
+
+  return (
+    <div
+      onClick={handleClick}
+      className="bar-root flex items-center gap-1.5 h-full px-2.5 cursor-pointer select-none"
+    >
+      <span className="text-white/40 text-[9px] uppercase tracking-wide">
+        {primary?.label.split(" ")[0] ?? "TZ"}
+      </span>
+      <span className="text-white/90 text-[12px] tabular-nums font-semibold">
+        {primary ? formatTime(now, primary.id) : "--:--"}
+      </span>
+    </div>
+  );
+}

--- a/src/components/AddZone.tsx
+++ b/src/components/AddZone.tsx
@@ -43,7 +43,7 @@ export function AddZone({ existingZoneIds, onAdd }: AddZoneProps) {
 
   if (!searching) {
     return (
-      <div className="py-1.5 px-5">
+      <div className="py-1 px-3">
         <button
           onClick={() => setSearching(true)}
           className="text-white/20 hover:text-white/40 text-[11px] cursor-pointer bg-transparent border-none transition-colors"
@@ -55,7 +55,7 @@ export function AddZone({ existingZoneIds, onAdd }: AddZoneProps) {
   }
 
   return (
-    <div className="px-5 py-2">
+    <div className="px-3 py-1.5">
       <input
         ref={inputRef}
         type="text"

--- a/src/components/TimeDisplay.tsx
+++ b/src/components/TimeDisplay.tsx
@@ -52,7 +52,7 @@ export function TimeDisplay({ selectedInstant, mode, onTimeTyped }: TimeDisplayP
 
   if (editing) {
     return (
-      <div className="flex items-center justify-center py-3 px-5 border-b border-white/[0.06]">
+      <div className="flex items-center justify-center py-1.5 px-3 border-b border-white/[0.06]">
         <input
           ref={inputRef}
           type="text"
@@ -68,7 +68,7 @@ export function TimeDisplay({ selectedInstant, mode, onTimeTyped }: TimeDisplayP
   }
 
   return (
-    <div className="flex items-center justify-center py-3 px-5 border-b border-white/[0.06]">
+    <div className="flex items-center justify-center py-1.5 px-3 border-b border-white/[0.06]">
       <button
         onClick={handleClick}
         className="text-[#4ade80] text-sm font-semibold cursor-pointer bg-transparent border-none hover:text-[#22c55e] transition-colors tracking-wide"

--- a/src/components/TimeSlider.tsx
+++ b/src/components/TimeSlider.tsx
@@ -7,7 +7,7 @@ interface TimeSliderProps {
 
 export function TimeSlider({ offset, onChange, onReset, mode }: TimeSliderProps) {
   return (
-    <div className="px-5 py-3 border-t border-white/[0.06]">
+    <div className="px-3 py-2 border-t border-white/[0.06]">
       <input
         type="range"
         min={-12}

--- a/src/components/ZoneRow.tsx
+++ b/src/components/ZoneRow.tsx
@@ -54,7 +54,7 @@ export function ZoneRow({ zoneId, label, info, canRemove, onRemove, onTimeTyped 
   };
 
   return (
-    <div className="group flex items-center gap-1.5 px-5 py-[7px] hover:bg-white/[0.03] transition-colors">
+    <div className="group flex items-center gap-1.5 px-3 py-[4px] hover:bg-white/[0.03] transition-colors">
       {/* Zone label */}
       <div className="w-[72px] min-w-[72px] flex items-baseline gap-1">
         <span className="text-[11px]">{flag}</span>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,19 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import App from "./App";
+import { BarApp } from "./BarApp";
 import "./App.css";
+
+const label = getCurrentWindow().label;
+if (label === "bar") {
+  document.body.classList.add("bar-window");
+}
+
+const Component = label === "bar" ? BarApp : App;
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <Component />
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

- **Fix window positioning on Windows**: `Position::TrayBottomCenter` places the popup window *below* the screen when the taskbar is at the bottom (Windows default). Now uses the physical tray icon coordinates from the click event to position the window *above* the system tray instead.
- **Fix deprecated API**: `menu_on_left_click` → `show_menu_on_left_click`
- **Update README**: Windows badge, download button, and installation instructions

## Test plan
- [ ] Click tray icon on Windows — window appears above the system tray clock
- [ ] Click elsewhere — window hides
- [ ] Right-click tray icon — Quit menu appears
- [ ] macOS behavior unchanged